### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -63,7 +63,6 @@ $(document).on('turbolinks:load', function(){
   function reloadMessages () {
     if($('.messages')[0]){
         var message_id = $('.message:last').data('id');
-    // console.log(message_id);
     }else {
         var message_id = 0
     }

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,14 +1,15 @@
 $(document).on('turbolinks:load', function(){
+  
   function buildHTML(message) {
     var content = message.content ? `${ message.content }` : "";
     var img = message.image ? `<img src= ${ message.image }>` : "";
     var html = `<div class="message" data-id="${message.id}">
                   <div class="upper-message">
                     <div class="upper-message__user-name">
-${message.user_name}
+                      ${message.user_name}
                     </div>
                     <div class="upper-message__date">
-${message.date}
+                      ${message.date}
                     </div>
                   </div>
                   <div class="lower-message">
@@ -21,6 +22,7 @@ ${message.date}
   return html;
   }
 
+//メッセージ送信の非同期化
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var message = new FormData(this);
@@ -43,9 +45,7 @@ ${message.date}
       function scrollBottom(){
         var target = $('.message').last();
         var position = target.offset().top + $('.messages').scrollTop();
-        $('.messages').animate({
-          scrollTop: position
-        }, 300, 'swing');
+        $('.messages').animate({scrollTop: position}, 300, 'swing');
       }
     })
 
@@ -57,4 +57,37 @@ ${message.date}
       $('.form-submit').prop('disabled', false);
     })
   })
-}); 
+
+//自動更新
+
+  function reloadMessages () {
+    if($('.messages')[0]){
+        var message_id = $('.message:last').data('id');
+    // console.log(message_id);
+    }else {
+        var message_id = 0
+    }
+
+    $.ajax({ 
+      url: 'api/messages', 
+      type: 'GET',
+      data: { id: message_id },
+      dataType: 'json'
+    })
+    
+    .done(function (messages) { 
+      console.log(messages);
+      var insertHTML = '';
+      messages.forEach(function (message) {
+        insertHTML = buildHTML(message); 
+        $('.messages').append(insertHTML);
+      })
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+    })   
+
+    .fail(function () {
+      alert('自動更新に失敗しました');
+    });
+  };
+  setInterval(reloadMessages, 5000);
+});

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,6 @@
+class Api::MessagesController < ApplicationController
+  def index
+    @group = Group.find(params[:group_id])
+    @messages = @group.messages.includes(:user).where('id > ?', params[:id])
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content      message.content
+  json.image        message.image.url
+  json.date         message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name    message.user.name
+  json.id           message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {id: message.id}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,6 @@
-json.id         @message.id
 json.content    @message.content
-json.date       @message.created_at.strftime("%Y/%m/%d %H:%M")
-json.user_name  @message.user.name
 json.image      @message.image.url
+json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.user_name @message.user.name
+#自動更新 idもデータとして渡す
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
動画キャプチャ
https://gyazo.com/53b684f9f40cdaabd5ec58195cd4753c

39af3ac

# what
自動更新機能の実装をしました

# why
メッセージ画面が自動で更新されることで、
自分以外のユーザーが送信したメッセージも更新時に表示されるようにするために
・5秒おきに自動で、ブラウザに表示されているメッセージのうち最新のidをサーバにリクエスト
・サーバー側でそれよりも後に投稿されたメッセージのみを取得＆レスポンス
・クライアント側で加工、メッセージ一覧に追加
上記3点の動きを実装しました。

ご確認のほどよろしくお願いいたします。
